### PR TITLE
env設定の導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,29 @@
-# demo_netapp
+## Environment 設定
 
-A new Flutter project.
+このプロジェクトでは、`--dart-define` を用いて実行時に環境変数を渡します。  
+`lib/config/app_env.dart` の `envProvider` から型付きで取得できます。
 
-## Getting Started
+### 利用可能な変数
 
-This project is a starting point for a Flutter application.
+| 変数名       | 必須         | デフォルト値 | 説明                                                |
+| ------------ | ------------ | ------------ | --------------------------------------------------- |
+| ENV          | 任意         | dev          | 環境名 (dev / stg / prod など)                      |
+| API_BASE_URL | 条件付き必須 | なし         | API のベース URL（`USE_FAKE=false` のとき必須）     |
+| USE_FAKE     | 任意         | true         | true ならバックエンド未接続でもフェイクデータで動作 |
 
-A few resources to get you started if this is your first Flutter project:
+### 実行例
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+#### フェイクデータで実行（API 不要）
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+```bash
+flutter run \
+  --dart-define=ENV=dev \
+  --dart-define=USE_FAKE=true
+```
+
+```bash
+flutter run \
+  --dart-define=ENV=dev \
+  --dart-define=USE_FAKE=false \
+  --dart-define=API_BASE_URL=https://jsonplaceholder.typicode.com
+```

--- a/lib/config/app_env.dart
+++ b/lib/config/app_env.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'app_env.g.dart';
+
+class AppEnv {
+  final String env; // dev/stg/prod
+  final String baseUrl;
+  final bool useFake;
+
+  const AppEnv({
+    required this.env,
+    required this.baseUrl,
+    required this.useFake,
+  });
+}
+
+@riverpod
+AppEnv env(Ref ref) {
+  const env = String.fromEnvironment('ENV', defaultValue: 'dev');
+
+  const base = String.fromEnvironment('API_BASE_URL', defaultValue: '');
+
+  const fakeStr = String.fromEnvironment('USE_FAKE', defaultValue: 'true');
+  final useFake = fakeStr.toLowerCase() == 'true';
+
+  if (!useFake && base.isEmpty) {
+    throw StateError('API_BASE_URL is required unless USE_FAKE=true');
+  }
+
+  return AppEnv(env: env, baseUrl: base, useFake: useFake);
+}

--- a/lib/config/app_env.g.dart
+++ b/lib/config/app_env.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'app_env.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$envHash() => r'7d210b1dcbd767d4ae17bd99cd5972beb15b7bc4';
+
+/// See also [env].
+@ProviderFor(env)
+final envProvider = AutoDisposeProvider<AppEnv>.internal(
+  env,
+  name: r'envProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$envHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef EnvRef = AutoDisposeProviderRef<AppEnv>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package


### PR DESCRIPTION
## 📝 概要

-  `--dart-define` から ENV / API_BASE_URL / USE_FAKE を読み込み、型付きの envProvider を生成（riverpod_generator使用）。
- まだUI/通信へは未接続（機能影響ほぼゼロ）。

- USE_FAKE=true なら API_BASE_URL 未設定でも起動可。
- 将来（PR6以降）で USE_FAKE=false にするとリモートへ切替予定。
## 🔄 変更点

dart-define を型付きProvider化（機能影響なし）

## ✅ 動作確認方法

```bash
flutter pub get
flutter run --dart-define=ENV=dev --dart-define=USE_FAKE=true
```
