### PR TITLE
userRepositoryのinterface対応

### DIFF
--- a/lib/core/network/dio_provider.dart
+++ b/lib/core/network/dio_provider.dart
@@ -16,6 +16,12 @@ Dio dio(Ref ref) {
       connectTimeout: const Duration(seconds: 10),
       receiveTimeout: const Duration(seconds: 10),
       sendTimeout: const Duration(seconds: 10),
+      headers: const {
+        'Accept': 'application/json',
+        'User-Agent': 'demo_netapp/0.1 (+flutter; dio)',
+      },
+      validateStatus: (status) =>
+          status != null && status >= 200 && status < 600,
     ),
   );
 

--- a/lib/core/network/dio_provider.g.dart
+++ b/lib/core/network/dio_provider.g.dart
@@ -6,7 +6,7 @@ part of 'dio_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$dioHash() => r'acf648d5582df88266a3261418201956565a58b1';
+String _$dioHash() => r'075d668bf200f0551f4a8480d2f6c2353605a497';
 
 /// See also [dio].
 @ProviderFor(dio)

--- a/lib/features/user/data/user_repository.dart
+++ b/lib/features/user/data/user_repository.dart
@@ -9,6 +9,8 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+part 'user_repository.g.dart';
+
 abstract class UserRepository {
   Future<UserDto> getUser(int id, {CancelToken? cancel});
 }

--- a/lib/features/user/data/user_repository.g.dart
+++ b/lib/features/user/data/user_repository.g.dart
@@ -6,7 +6,7 @@ part of 'user_repository.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$userRepositoryHash() => r'd664083e60054612aa5454fb96bff6f14d99a28a';
+String _$userRepositoryHash() => r'e48d5bc39a0eac129714ebcd5d4de2a6cc81e7c6';
 
 /// See also [userRepository].
 @ProviderFor(userRepository)


### PR DESCRIPTION
## 📝 概要

UserRepositoryをinterface化して、差し替え可能な状態に変更
(e.g. API -> DBなど)

## 🔄 変更点

上記対応に追加してUserAgent設定がなかったため403で弾かれてしまう問題が発生していたためそれの対応

## ✅ 動作確認方法

<!-- コマンドや操作手順を記載 -->

```bash
flutter pub get
flutter run --dart-define=USE_FAKE=true
```
